### PR TITLE
Fix to Production PostgreSQL Error

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -301,7 +301,7 @@ func initialize(servicePort, databaseURL, redisURL, loggingURL, statsdURL, certP
 					return
 				}
 
-				err := svc.Db.NewUser(elon_uid, givenName, surname, email, affiliation)
+				err := svc.Db.NewUser(elon_uid, givenName, surname, email, strings.ToLower(affiliation))
 				if err != nil {
 					svc.Log.Error(err.Error(), nil)
 					w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
In response to the error message in the production environment, lowercasing affiliation before creating a new user should be preventative. 

```
time="2024-03-12T20:41:01Z" level=error msg="ERROR: invalid input value for enum affiliation: \"Student\" (SQLSTATE 22P02)"
```

