### PR TITLE
Fix BuildingById Endpoint

### DIFF
--- a/backend/locations/v1/buildings/buildings.go
+++ b/backend/locations/v1/buildings/buildings.go
@@ -3,7 +3,6 @@ package buildings_v1
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/elonsoc/ods/backend/service"
@@ -77,7 +76,7 @@ func (br *BuildingsRouter) BuildingByIdHandler(w http.ResponseWriter, r *http.Re
     start := time.Now()
     w.Header().Set("Content-Type", "application/json")
 
-    buildingId := strings.ToLower(chi.URLParam(r, "buildingID"))
+    buildingId := chi.URLParam(r, "buildingID")
 
     building, err := br.Svcs.Db.GetBuildingById(buildingId)
     if err != nil {

--- a/backend/locations/v1/buildings/buildings_test.go
+++ b/backend/locations/v1/buildings/buildings_test.go
@@ -172,7 +172,3 @@ func TestRootHandler(t *testing.T) {
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Contains(t, string(body), "mcewen")
 }
-
-func strPtr(s string) *string { return &s }
-func float64Ptr(f float64) *float64 { return &f }
-func timePtr(t time.Time) *time.Time { return &t }


### PR DESCRIPTION
Seeing as the ID of the buildings are a case-sensitive string, it is necessary to respect casing when accepting a URL param. Therefore, the removal of the tolower() string when accepting the URL param fixes the issue. 